### PR TITLE
set version of "should" to 3.x to fix unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	},
   "devDependencies": {
     "mocha": "*",
-    "should": "*",
+    "should": "^3.0.0",
     "jade": "*"
   }
 }


### PR DESCRIPTION
using version 4.x of should and later cause unit tests to break.