### PR TITLE
use jsdom-nogyp instead of jsdom to avoid issues building Contextify on ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var jsdom = require('jsdom');
+var jsdom = require('jsdom-nogyp');
 var rewire = require('rewire');
 var path = require('path');
 var fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   	"test": "make test"
 	},
 	"dependencies": {
-	  "jsdom": "*",
+	  "jsdom-nogyp": "*",
 	  "rewire": "*"
 	},
   "devDependencies": {


### PR DESCRIPTION
"npm install" installs jsdom, which needs to build Contextify, and on Windows that can be a nightmare.  This PR fixes that problem but introduces the limitation that script tags embedded in the DOM are not evaluated.