### PR TITLE
Use Node v12 and the latest jsdom

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var jsdom = require('jsdom-nogyp');
+var jsdom = require('jsdom');
 var rewire = require('rewire');
 var path = require('path');
 var fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,30 @@
 {
   "name": "benv",
-  "version": "0.1.8",
+  "version": "2.0.0",
   "description": "Stub a browser environment and test your client-side code in node.js.",
+  "main": "index.js",
+  "engines": {
+    "node": ">= 0.12.x"
+  },
+  "directories": {
+    "test": "test"
+  },
+  "dependencies": {
+    "rewire": "^2.3.1",
+    "jsdom": "4.x"
+  },
+  "devDependencies": {
+    "mocha": "^2.2.1",
+    "should": "^3.3.2",
+    "jade": "^1.9.2"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/craigspaeth/benv.git"
+  },
   "keywords": [
     "browser",
     "tests",
@@ -9,28 +32,10 @@
     "stub",
     "jsdom"
   ],
-  "repository": {
-    "type": "git",
-    "url": "http://github.com/artsy/benv.git"
+  "author": "Craig Spaeth",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/craigspaeth/benv/issues"
   },
-  "author": {
-    "name": "Craig Spaeth",
-    "email": "craigspaeth@gmail.com",
-    "url": "http://craigspaeth.com"
-  },
-  "engines": {
-    "node": ">= 0.10.x"
-  },
-  "scripts": {
-  	"test": "make test"
-	},
-	"dependencies": {
-	  "jsdom": "3.x",
-	  "rewire": "*"
-	},
-  "devDependencies": {
-    "mocha": "*",
-    "should": "^3.0.0",
-    "jade": "*"
-  }
+  "homepage": "https://github.com/craigspaeth/benv"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "benv",
-  "version": "2.0.0",
+  "version": "0.2.0",
   "description": "Stub a browser environment and test your client-side code in node.js.",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Stub a browser environment and test your client-side code in node.js.",
   "main": "index.js",
   "engines": {
-    "node": ">= 0.12.x"
+    "node": ">= 0.12.0"
   },
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "benv",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Stub a browser environment and test your client-side code in node.js.",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "benv",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Stub a browser environment and test your client-side code in node.js.",
   "keywords": [
     "browser",
@@ -25,7 +25,7 @@
   	"test": "make test"
 	},
 	"dependencies": {
-	  "jsdom-nogyp": "*",
+	  "jsdom": "3.x",
 	  "rewire": "*"
 	},
   "devDependencies": {


### PR DESCRIPTION
Hopefully this doesn't cause subtle issues b/c of the difference with io.js and Node's implementation of vm, but jsdom-nogyp hasn't been updated in a very long time and jsdom 4.x solves the contextify challenge.

See https://github.com/facebook/jest/issues/267 for a related thread in Jest.