### PR TITLE
Add support for .pug templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ benv.render('./views/artwork.jade', {
 });
 ````
 
-Currently only supports [.jade](https://github.com/visionmedia/jade) templates, but please contribute others :)
+Currently only supports [.jade](https://github.com/pugjs/pug/tree/v1.x.x) and [.pug](https://github.com/pugjs/pug) templates, but please contribute others :)
 
 ### benv.requireWithJadeify(filename, varNames)
 

--- a/index.js
+++ b/index.js
@@ -87,12 +87,16 @@ module.exports.require = function(filename, globalVarName) {
 
 module.exports.render = function(filename, data, callback) {
   if (!window) throw Error('You must run benv.setup first.');
-  if (!filename.match('.jade')) throw Error('Could not identify template type');
+  if (!filename.match('.jade') && !filename.match('.pug')) throw Error('Could not identify template type');
   var fullPath = path.resolve(path.dirname(module.parent.filename), filename);
-  var html = require('jade').compile(
+
+  var engine = filename.match('.jade') ? require('jade') : require('pug');
+
+  var html = engine.compile(
     fs.readFileSync(fullPath),
     { filename: fullPath }
   )(data);
+
   jsdom.env(html, function(err, w) {
     var scriptEls = w.document.getElementsByTagName('script');
     Array.prototype.forEach.call(scriptEls, function(el) {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
     "jsdom": ">= 4.0"
   },
   "devDependencies": {
+    "jade": "^1.9.2",
     "mocha": "^2.2.1",
-    "should": "^3.3.2",
-    "jade": "^1.9.2"
+    "pug": "^2.0.0-beta6",
+    "should": "^3.3.2"
   },
   "scripts": {
     "test": "mocha -r should"

--- a/test/index.js
+++ b/test/index.js
@@ -120,6 +120,16 @@ describe('benv.render', function() {
     });
   });
 
+  it('renders pug templates', function(done) {
+    benv.setup(function(){
+      var $ = benv.require('./libs/zepto.js', 'Zepto');
+      benv.render(__dirname + '/libs/template.pug', {}, function() {
+        $('body').html().should.include('Hello World')
+        done();
+      });
+    });
+  });
+
   it('renders just the body from the template', function(done) {
     benv.setup(function(){
       var $ = benv.require('./libs/zepto.js', 'Zepto');

--- a/test/libs/template.pug
+++ b/test/libs/template.pug
@@ -1,0 +1,4 @@
+html
+  head
+  body
+    h1 Hello World


### PR DESCRIPTION
Added support for .pug files (Jade was renamed to Pug).
Added a corresponding test too.

Since Pug has breaking changes and still in beta, I kept both of them around.

P.S. Can I submit a PR rewriting this in ES6 ? Mostly for aesthetics but there might be code which can be written better with ES6.