### PR TITLE
@craigspaeth => use old-api for jsdom v10

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var jsdom = require('jsdom');
+var jsdom= require('jsdom/lib/old-api.js');
 var rewire = require('rewire');
 var path = require('path');
 var fs = require('fs');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "benv",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Stub a browser environment and test your client-side code in node.js.",
   "main": "index.js",
   "engines": {
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "rewire": "^2.3.1",
-    "jsdom": ">= 4.0"
+    "jsdom": ">= 10.0"
   },
   "devDependencies": {
     "jade": "^1.9.2",


### PR DESCRIPTION
Addresses: https://github.com/artsy/benv/issues/36

This bumps the version of benv to `3.3` and pins jsdom at `>=10.0` so we can safely reference `/old-api.js`.