### PR TITLE
Fixing tiny markdown issue in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ benv.expose({
   Backbone: require('backbone'),
   App: {}
 })
-```
+````
 
 ### benv.teardown(clearDOM = false)
 


### PR DESCRIPTION
Just noticed that the `### benv.teardown(clearDOM = false)` section wasn't rendering properly on GitHub.